### PR TITLE
Deployment plan generation performance optimization

### DIFF
--- a/src/main/java/com/oneops/transistor/service/BomRfcBulkProcessor.java
+++ b/src/main/java/com/oneops/transistor/service/BomRfcBulkProcessor.java
@@ -42,6 +42,7 @@ import com.oneops.transistor.exceptions.TransistorException;
 import org.apache.log4j.Logger;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class BomRfcBulkProcessor {
 	static Logger logger = Logger.getLogger(BomRfcBulkProcessor.class);
@@ -126,7 +127,8 @@ public class BomRfcBulkProcessor {
 		
 		List<CmsCIRelation> mfstPlatComponents = cmProcessor.getFromCIRelations(platformCi.getCiId(), null, "Requires", null);
 		if (mfstPlatComponents.size() > 0) {
-		
+			Long releaseId  = rfcProcessor.getOpenReleaseIdByNs(getReleaseNs(nsPath).toString(), null, userId);
+
 			String manifestNs = mfstPlatComponents.get(0).getNsPath();
 			boolean isPartial = isPartialDeployment(manifestNs);
 			
@@ -140,8 +142,9 @@ public class BomRfcBulkProcessor {
 				BomRfc newBom = bootstrapNewBom(startingPoint, bindingRel.getToCiId(), 1);
 				boms.add(newBom);	
 				mfstId2nodeId.put(String.valueOf(newBom.manifestCiId) + "-" + 1, new ArrayList<BomRfc>(Arrays.asList(newBom)));
-				
+				long startTime = System.currentTimeMillis();
 				boms.addAll(processNode(newBom, bindingRel, mfstId2nodeId, manifestDependsOnRels, 1, usePercent, 1));
+				logger.info("Time to process Nodes:"+ (System.currentTimeMillis()-startTime));
 				startingPoint = getStartingPoint(mfstPlatComponents, boms);
 			}
 			// this is needed to work around ibatis 
@@ -155,8 +158,6 @@ public class BomRfcBulkProcessor {
 			processVars(boms, cloudVars, globalVars, localVars);
 			logger.info(nsPath + " >>> " + platformCi.getCiName() + ", starting creating rfcs");
 			long bomCreationStartTime = System.currentTimeMillis();
-			Long releaseId = null;
-			
 			ExistingRels existingRels = new ExistingRels(nsPath);
 			Map<String, CmsCI> existingCIs = getExistingCis(bindingRel.getToCiId(), nsPath);
 			Map<String, CmsRfcCI> existingRFCs = getOpenRFCs(nsPath);
@@ -429,7 +430,6 @@ public class BomRfcBulkProcessor {
 									 Long releaseId) {
 		
 		long nsId = trUtil.verifyAndCreateNS(nsPath);
-		
 		Map<String, BomRfc> bomMap = new HashMap<String, BomRfc>();
 		for (BomRfc bom : boms) {
 			bomMap.put(bom.nodeId, bom);
@@ -463,6 +463,7 @@ public class BomRfcBulkProcessor {
 		Set<Long> bomCiIds = new HashSet<Long>();
 		Map<Long, List<String>> manifestPropagations = new HashMap<Long, List<String>>();
 		long timeTakenByPropagation = 0;
+		long rfcInsertStartTime = System.currentTimeMillis();
 		//now lets create rfcs
 		int realExecOrder = startExecOrder;
 		int numberOfRFCs = 0;
@@ -502,12 +503,13 @@ public class BomRfcBulkProcessor {
 						}
 						incOrder = incOrder || rfcCreated;
 					}
+					
 					if (bom.rfc != null) {
 						bomCiIds.add(bom.rfc.getCiId());
 					}
 					if (rfcCreated) {
 						numberOfRFCs++;
-						if (numberOfRFCs % 10 == 0) {
+						if (numberOfRFCs % 100 == 0) {
 							logger.info(">>> Inserted " + numberOfRFCs + " rfcs;");
 						}
 					}
@@ -516,11 +518,11 @@ public class BomRfcBulkProcessor {
 			if (incOrder) realExecOrder++;
 		}
 		
-		logger.info(">>> Inserted " + numberOfRFCs + " rfcs;");
+		logger.info(">>> Inserted " + numberOfRFCs + " rfcs; time spent - "+(System.currentTimeMillis()-rfcInsertStartTime));
 
 
 		logger.info(">>> Done with RFCs working on relations...");
-
+		long rfcRelationInsertStartTime = System.currentTimeMillis();
 		//lets create dependsOn Relations
 		//TODO question should we propagate rel attrs
 		int maxRfcExecOrder = getMaxRfcExecOrder(boms);
@@ -576,14 +578,14 @@ public class BomRfcBulkProcessor {
 						timeTakenByPropagation = timeTakenByPropagation + (endTime - startTime);
 						increaseMaxOrder = true;
 					}
-					if (numberOfRelRFCs % 10 == 0) {
+					if (numberOfRelRFCs % 100 == 0) {
 						logger.info(">>> Inserted " + numberOfRelRFCs + " relation rfcs;");
 					}
 				}
 			}
 		}
 		
-		logger.info(">>> Inserted " + numberOfRelRFCs + " relation rfcs;");
+		logger.info(">>> Inserted " + numberOfRelRFCs + " relation rfcs; time spent - "+ (System.currentTimeMillis()- rfcRelationInsertStartTime));
 		
 		//Now create dummy updates for all the dependency-propagations needed
 		if (propagations.size() > 0) {
@@ -622,8 +624,20 @@ public class BomRfcBulkProcessor {
 		logger.info(nsPath + " >>> Total time taken by propagation in seconds: " + timeTakenByPropagation/1000);
 		return maxExecOrder;
 	}
-	
-	private void propagate4ComputeReplace(List<CmsRfcCI> bomCompRfcs) {
+
+    private StringBuilder getReleaseNs(String nsPath) {
+        String[] nsParts = nsPath.split("/");
+        StringBuilder releaseNs = new StringBuilder();
+        for (int i = 1; i < nsParts.length; i++) {
+            if (nsParts[i].equals("_design")) break;
+            releaseNs.append("/").append(nsParts[i]);
+            if (nsParts[i].equals("bom")) break;
+            if (nsParts[i].equals("manifest")) break;
+        }
+        return releaseNs;
+    }
+
+    private void propagate4ComputeReplace(List<CmsRfcCI> bomCompRfcs) {
 		for (CmsRfcCI rfc : bomCompRfcs) {
 			for (CmsCIRelation rel : cmProcessor.getToCIRelationsNakedNoAttrs(rfc.getCiId(), "bom.DependsOn", null, "bom.Lb")) {
 				cmRfcMrgProcessor.createDummyUpdateRfc(rel.getFromCiId(), null, rfc.getExecOrder() + 1, rfc.getCreatedBy());
@@ -859,15 +873,13 @@ public class BomRfcBulkProcessor {
 	}
 	
 	private void createBomRfc(CmsRfcCI rfc, CmsCI existingCi, CmsRfcCI existingRfc, Long releaseId) {
+		if (rfc.getReleaseId()==0 && releaseId!=null){
+			rfc.setReleaseId(releaseId);
+		}
 		if (rfc.getCiId() == 0) {
 			//this is add rfc
-			if (releaseId == null) {
-				if (rfc.getReleaseId() > 0) {
-					releaseId = rfc.getReleaseId();
-				} else {
-					rfc.setReleaseId(rfcProcessor.getOpenReleaseIdByNs(rfc.getReleaseNsPath(), null, rfc.getCreatedBy()));
-				}
-			}
+			
+			
 			rfc.setIsActiveInRelease(true);
 			rfc.setRfcAction("add");
 
@@ -879,13 +891,7 @@ public class BomRfcBulkProcessor {
 		} else {
 			//need to figure out delta and create update rfc
 			if (needUpdateRfc(rfc, existingCi)) {
-				if (releaseId == null) {
-					if (rfc.getReleaseId() > 0) {
-						releaseId = rfc.getReleaseId();
-					} else {
-						rfc.setReleaseId(rfcProcessor.getOpenReleaseIdByNs(rfc.getReleaseNsPath(), null, rfc.getCreatedBy()));
-					}
-				}
+				
 				rfc.setIsActiveInRelease(true);
 				if (rfc.getRfcId() == 0) {
 					rfcProcessor.createBomRfc(rfc);
@@ -935,15 +941,12 @@ public class BomRfcBulkProcessor {
 	}
 
 	private void createBomRelationRfc(CmsRfcRelation rfc, ExistingRels existingRels, Long releaseId) {
+		if (rfc.getReleaseId()==0 && releaseId!=null){
+			rfc.setReleaseId(releaseId);
+		}
 		if (rfc.getCiRelationId() == 0) {
 			//this is add rfc
-			if (releaseId == null) {
-				if (rfc.getReleaseId() > 0) {
-					releaseId = rfc.getReleaseId();
-				} else {
-					rfc.setReleaseId(rfcProcessor.getOpenReleaseIdByNs(rfc.getReleaseNsPath(), null, rfc.getCreatedBy()));
-				}
-			}
+			
 			rfc.setIsActiveInRelease(true);
 			rfc.setRfcAction("add");
 
@@ -956,13 +959,6 @@ public class BomRfcBulkProcessor {
 			//need to figure out delta and create update rfc
 			CmsCIRelation existingRel = existingRels.getExistingRel(rfc.getRelationName(), rfc.getFromCiId(), rfc.getToCiId());
 			if (needUpdateRfcRelation(rfc, existingRel)) {
-				if (releaseId == null) {
-					if (rfc.getReleaseId() > 0) {
-						releaseId = rfc.getReleaseId();
-					} else {
-						rfc.setReleaseId(rfcProcessor.getOpenReleaseIdByNs(rfc.getReleaseNsPath(), null, rfc.getCreatedBy()));
-					}
-				}
 				rfc.setIsActiveInRelease(true);
 				rfc.setRfcAction("update");
 				if (rfc.getRfcId() == 0) {
@@ -1159,7 +1155,7 @@ public class BomRfcBulkProcessor {
 	    
 		long nsId = trUtil.verifyAndCreateNS(nsPath);
 		List<CmsLink> dependsOnlinks = cmRfcMrgProcessor.getLinks(nsPath, "bom.DependsOn");
-		//convert to map for traversing the path
+		//convert to depOnMap for traversing the path
 		Map<Long, Map<String,List<Long>>> dependsOnMap = new HashMap<Long, Map<String,List<Long>>>();
 		for (CmsLink link : dependsOnlinks) {
 			if (!dependsOnMap.containsKey(link.getFromCiId())) {
@@ -1171,19 +1167,34 @@ public class BomRfcBulkProcessor {
 			dependsOnMap.get(link.getFromCiId()).get(link.getToClazzName()).add(link.getToCiId());
 		}
 		long counter = 0;
+		long lengthSum = 0;
+		long lengthCounter = 0;  
 		
 		Set<String> relRfcGoids = new HashSet<String>();
+		Map<Long, List<CmsCIRelation>> depOnMap = null;
+		Map<Long, List<CmsCIRelation>> managedViaMap = null;
 		for (CmsCIRelation mfstCiRel : mfstCiRels) {
 			CmsCI mfstCi = mfstCiRel.getToCi();
 			//first lets check if we even have an add rfc for this Ci
 			//if (newRfcExists(mfstCi.getCiId(), bomsMap)) {
-			List<CmsCIRelation> mfstMngViaRels = cmProcessor.getFromCIRelationsNaked(mfstCi.getCiId(), null, "ManagedVia", null);
+			
+			if (depOnMap==null) {
+				depOnMap = cmProcessor.getCIRelations(mfstCi.getNsPath(), null, "DependsOn", null, null).stream().collect(Collectors.groupingBy(CmsCIRelation::getFromCiId));
+			}
+			if (managedViaMap==null){
+				managedViaMap = cmProcessor.getCIRelations(mfstCi.getNsPath(), null, "ManagedVia", null, null).stream().collect(Collectors.groupingBy(CmsCIRelation::getFromCiId));
+			}
+			
+			List<CmsCIRelation> mfstMngViaRels = managedViaMap.containsKey(mfstCi.getCiId())?managedViaMap.get(mfstCi.getCiId()):new ArrayList<>();
+
 			for (CmsCIRelation mfstMngViaRel : mfstMngViaRels) {
 				// lets find the path 
 				//List<String> pathClasses = getTraversalPath(mfstMngViaRel);
 				List<String> pathClasses = enableBFS?
-						getDpOnPathBfs(mfstMngViaRel.getFromCiId(), mfstMngViaRel.getToCiId()):
-						getDpOnPath(mfstMngViaRel.getFromCiId(), mfstMngViaRel.getToCiId());
+						getDpOnPathBfs(mfstMngViaRel.getFromCiId(), mfstMngViaRel.getToCiId(), depOnMap):
+						getDpOnPath(mfstMngViaRel.getFromCiId(), mfstMngViaRel.getToCiId(), depOnMap);
+				lengthCounter++;
+				lengthSum+=pathClasses.size();
 				if (pathClasses.size()==0) {
 					String err = "Can not traverse ManagedVia relation using DependsOn path from ci " + mfstMngViaRel.getFromCiId() + ", to ci " + mfstMngViaRel.getToCiId() + "\n";
 					err += mfstMngViaRel.getComments();
@@ -1237,6 +1248,7 @@ public class BomRfcBulkProcessor {
 			}
 		}
 		logger.info("Bom ManagedVia Relation Counter:"+ counter);
+		logger.info("Avg length:"+(double)lengthSum/lengthCounter);
 	};
 
 	private void processSecuredByRels(List<CmsCIRelation> mfstCiRels, Map<Long, List<BomRfc>> bomsMap, String nsPath,  String user, ExistingRels existingRels, Long releaseId) {
@@ -1289,14 +1301,7 @@ public class BomRfcBulkProcessor {
 			}
 		}
 		if (path.size() ==0) {
-			//this should be our target list
-			for (long toCiId : targets) {
-				//lets check if this guy is related to the right mfstCi
-				//TODO this could be not nessesary
-				//if (cmRfcMrgProcessor.getToCIRelationsNakedNoAttrs(rel.getToCiId(), null, "RealizedAs", nextMfstClass).size() >0) {
-					listOfTargets.add(toCiId);
-				//}
-			}
+			listOfTargets.addAll(targets);
 		} else {
 			for (long toCiId : targets) {
 				listOfTargets.addAll(getLeafsByPath(toCiId, new LinkedList<String>(path), targetMfstCiId, dependsOnMap));
@@ -1305,7 +1310,7 @@ public class BomRfcBulkProcessor {
 		return listOfTargets;
 	}
 
-	private List<String> getDpOnPathBfs(long fromId, long endId) { // implement shortest path search (modified BFS)
+	private List<String> getDpOnPathBfs(long fromId, long endId, Map<Long, List<CmsCIRelation>> map) { // implement shortest path search (modified BFS)
 		Map<Long, String> idToClassNameMap = new HashMap<>();
 		Map<Long, Long> parents = new HashMap<>();
 		Queue<Long> queue = new LinkedList<>();
@@ -1324,7 +1329,7 @@ public class BomRfcBulkProcessor {
 				} while ((current = parents.get(current)) != null);
 				return pathClasses;
 			}
-			List<CmsCIRelation> dependsOnRelations = cmProcessor.getFromCIRelations(current, null, "DependsOn", null);
+			List<CmsCIRelation> dependsOnRelations = map.get(current);
 			for (CmsCIRelation dependsOnRelation : dependsOnRelations) {
 				CmsCI toCi = dependsOnRelation.getToCi();
 				idToClassNameMap.put(toCi.getCiId(), toCi.getCiClassName());
@@ -1338,15 +1343,15 @@ public class BomRfcBulkProcessor {
 		return new ArrayList<>();
 	}
 
-	private List<String> getDpOnPath(long fromId, long endId) {
+	private List<String> getDpOnPath(long fromId, long endId, Map<Long, List<CmsCIRelation>> map) {
 		List<String> pathClasses = new ArrayList<String>();
-		List<CmsCIRelation> dponRels = cmProcessor.getFromCIRelations(fromId, null, "DependsOn", null);
+		List<CmsCIRelation> dponRels = map.get(fromId);
 		for (CmsCIRelation dponRel : dponRels) {
 			if (dponRel.getToCi().getCiId() == endId) {
 				pathClasses.add(dponRel.getToCi().getCiClassName());
 				return pathClasses;
 			} else {
-				List<String> downClasses = getDpOnPath(dponRel.getToCiId(), endId);
+				List<String> downClasses = getDpOnPath(dponRel.getToCiId(), endId, map);
 				if (downClasses.size() > 0) {
 					pathClasses.add(dponRel.getToCi().getCiClassName());
 					pathClasses.addAll(downClasses);

--- a/src/main/java/com/oneops/transistor/service/BomRfcBulkProcessor.java
+++ b/src/main/java/com/oneops/transistor/service/BomRfcBulkProcessor.java
@@ -1329,7 +1329,7 @@ public class BomRfcBulkProcessor {
 				} while ((current = parents.get(current)) != null);
 				return pathClasses;
 			}
-			List<CmsCIRelation> dependsOnRelations = map.get(current);
+			List<CmsCIRelation> dependsOnRelations = map.containsKey(current) ? map.get(current) : new ArrayList<>();
 			for (CmsCIRelation dependsOnRelation : dependsOnRelations) {
 				CmsCI toCi = dependsOnRelation.getToCi();
 				idToClassNameMap.put(toCi.getCiId(), toCi.getCiClassName());
@@ -1345,7 +1345,7 @@ public class BomRfcBulkProcessor {
 
 	private List<String> getDpOnPath(long fromId, long endId, Map<Long, List<CmsCIRelation>> map) {
 		List<String> pathClasses = new ArrayList<String>();
-		List<CmsCIRelation> dponRels = map.get(fromId);
+        List<CmsCIRelation> dponRels = map.containsKey(fromId) ? map.get(fromId) : new ArrayList<>();
 		for (CmsCIRelation dponRel : dponRels) {
 			if (dponRel.getToCi().getCiId() == endId) {
 				pathClasses.add(dponRel.getToCi().getCiClassName());


### PR DESCRIPTION
More optimizations for deployment plan generation:
 - create release and use releaseId instead of polling db for open release for each rfc/rfcrelation insert
 - load all DependsOn and ManagedVia relationships by nsPath once and group by fromCi instead of querying db as we traverse the paths for each node 
 Output more stats: avg path length, processing times for rfc/rfcrel inserts and nodes processing.